### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) server that provides access to the Strava API. It allows language models to query athlete activities data from the Strava API.
 
+<a href="https://glama.ai/mcp/servers/kjgj5ovtdq">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/kjgj5ovtdq/badge" alt="Strava Server MCP server" />
+</a>
+
 ## Available Tools
 
 The server exposes the following tools:


### PR DESCRIPTION
This PR adds a badge for the [Strava MCP Server](https://glama.ai/mcp/servers/kjgj5ovtdq) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/kjgj5ovtdq">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/kjgj5ovtdq/badge" alt="Strava Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.